### PR TITLE
Nuget fix

### DIFF
--- a/AvaStride/AvaStride.csproj
+++ b/AvaStride/AvaStride.csproj
@@ -27,8 +27,5 @@
 		<PackageReference Include="Avalonia" Version="11.*" />
 		<PackageReference Include="Stride.Core" Version="4.2.*" PrivateAssets="contentfiles;analyzers" />
 		<PackageReference Include="Stride.Engine" Version="4.2.*" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Particles" Version="4.2.*" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Physics" Version="4.2.*" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.UI" Version="4.2.*" PrivateAssets="contentfiles;analyzers" />
 	</ItemGroup>
 </Project>

--- a/AvaStride/AvaloniaInStride.cs
+++ b/AvaStride/AvaloniaInStride.cs
@@ -1,21 +1,9 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input;
 using Avalonia.Media;
-using Avalonia.Styling;
 using Avalonia.Threading;
 using Stride.Core;
 using Stride.Engine;
-using Stride.UI.Controls;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
-using Vortice.Vulkan;
 
 namespace AvaStride
 {

--- a/AvaStride/GameCallbackSystem.cs
+++ b/AvaStride/GameCallbackSystem.cs
@@ -1,11 +1,6 @@
 ﻿using Stride.Core;
 using Stride.Engine;
 using Stride.Games;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AvaStride
 {

--- a/AvaStride/Module.cs
+++ b/AvaStride/Module.cs
@@ -1,0 +1,14 @@
+﻿using Stride.Core;
+using Stride.Core.Reflection;
+using System.Reflection;
+
+namespace AvaStride;
+internal class Module
+{
+	[ModuleInitializer]
+	public static void Initialize()
+	{
+		// Make sure that this assembly is registered
+		AssemblyRegistry.Register(typeof(Module).GetTypeInfo().Assembly, AssemblyCommonCategories.Assets);
+	}
+}

--- a/AvaStride/UISyncScript.cs
+++ b/AvaStride/UISyncScript.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace AvaStride
 {
+    [ComponentCategory("UI")]
     public abstract class UISyncScript : SyncScript
     {
         public abstract void UIUpdate(Window window, TimeSpan t);


### PR DESCRIPTION
Added the Module class to project. This is needed for Gamestudio to be able to see serializable scripts in a nuget package.

removed unneeded libraries

added handy ComponentCategory attribute for orginization (Maybe should be `Avalonia - UI` instead of `UI`)